### PR TITLE
Migrate budget-api tag cache to context-aware CacheProvider methods

### DIFF
--- a/budget/budget-api/adapter/tags/rest/ristretto_cached_rest_tags_repositor.go
+++ b/budget/budget-api/adapter/tags/rest/ristretto_cached_rest_tags_repositor.go
@@ -62,7 +62,7 @@ func (repository *RistrettoCachedSearchTagRepository) GetAllTags(ctx context.Con
 
 	cacheKey := fmt.Sprintf("search_tags_user_%s", *user.UserName)
 
-	cachedSearchTags, found := repository.getFromTheCache(cacheKey, *user.UserName)
+	cachedSearchTags, found := repository.getFromTheCache(ctx, cacheKey)
 	if found {
 		return cachedSearchTags, nil
 	}
@@ -70,8 +70,8 @@ func (repository *RistrettoCachedSearchTagRepository) GetAllTags(ctx context.Con
 	return repository.fetchFromDelegate(ctx, cacheKey, *user.UserName)
 }
 
-func (repository *RistrettoCachedSearchTagRepository) getFromTheCache(cacheKey string, userName string) ([]tags.SearchTag, bool) {
-	if cachedValue, found := repository.CacheProvider.Get(cacheKey); found {
+func (repository *RistrettoCachedSearchTagRepository) getFromTheCache(ctx context.Context, cacheKey string) ([]tags.SearchTag, bool) {
+	if cachedValue, found := repository.CacheProvider.GetContext(ctx, cacheKey); found {
 		repository.logger.LogDebugfFor("Cache hit for key: %s", cacheKey)
 		var searchTags []tags.SearchTag
 		err := json.Unmarshal([]byte(cachedValue), &searchTags)
@@ -94,25 +94,17 @@ func (repository *RistrettoCachedSearchTagRepository) fetchFromDelegate(ctx cont
 		repository.logger.LogErrorfFor("Error fetching search tags from delegate: %s", err)
 		return nil, err
 	}
-	err = repository.setToTheCache(cacheKey, searchTags, userName)
-	if err != nil {
-		repository.logger.LogErrorfFor("Error setting search tags to cache: %s", err)
-	}
+	repository.setToTheCache(ctx, cacheKey, searchTags)
 	return searchTags, nil
 }
 
-func (repository *RistrettoCachedSearchTagRepository) setToTheCache(cacheKey string, searchTags []tags.SearchTag, userName string) error {
+func (repository *RistrettoCachedSearchTagRepository) setToTheCache(ctx context.Context, cacheKey string, searchTags []tags.SearchTag) {
 	jsonData, err := json.Marshal(searchTags)
 	if err != nil {
 		repository.logger.LogErrorfFor("Error marshalling search tags for key: %s, error: %s", cacheKey, err)
-		return err
+		return
 	}
 
-	err = repository.CacheProvider.Set(cacheKey, string(jsonData))
-	if err != nil {
-		repository.logger.LogErrorfFor("Error setting cache for key: %s, error: %s", cacheKey, err)
-	} else {
-		repository.logger.LogDebugfFor("Cache set for key: %s", cacheKey)
-	}
-	return err
+	repository.CacheProvider.SetContext(ctx, cacheKey, string(jsonData))
+	repository.logger.LogDebugfFor("Cache set for key: %s", cacheKey)
 }

--- a/budget/budget-api/adapter/tags/rest/ristretto_cached_rest_tags_repositor_test.go
+++ b/budget/budget-api/adapter/tags/rest/ristretto_cached_rest_tags_repositor_test.go
@@ -1,0 +1,109 @@
+//go:build test
+
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/go-playground/assert/v2"
+	"github.com/mrflick72/budget/budget-api/domain/tags"
+	"github.com/mrflick72/onlyone-portal/core-services/golang-web-framework/logging"
+	"github.com/mrflick72/onlyone-portal/core-services/golang-web-framework/middleware/security"
+	"github.com/stretchr/testify/mock"
+)
+
+type CacheProviderMock struct {
+	mock.Mock
+}
+
+func (m *CacheProviderMock) Get(key string) (string, bool) {
+	args := m.Called(key)
+	return args.String(0), args.Bool(1)
+}
+
+func (m *CacheProviderMock) Set(key string, value string) error {
+	args := m.Called(key, value)
+	return args.Error(0)
+}
+
+func (m *CacheProviderMock) Evict(key string) error {
+	args := m.Called(key)
+	return args.Error(0)
+}
+
+func (m *CacheProviderMock) GetContext(ctx context.Context, key string) (string, bool) {
+	args := m.Called(ctx, key)
+	return args.String(0), args.Bool(1)
+}
+
+func (m *CacheProviderMock) SetContext(ctx context.Context, key string, value string) error {
+	args := m.Called(ctx, key, value)
+	return args.Error(0)
+}
+
+func (m *CacheProviderMock) EvictContext(ctx context.Context, key string) error {
+	args := m.Called(ctx, key)
+	return args.Error(0)
+}
+
+func userContextFor(userName string) context.Context {
+	u := userName
+	return context.WithValue(context.Background(), "user", security.User{UserName: &u})
+}
+
+func TestGetAllTagsReturnsCachedValueOnCacheHitWithoutCallingDelegate(t *testing.T) {
+	ctx := userContextFor("A_USER")
+	cacheKey := "search_tags_user_A_USER"
+	cachedTags := []tags.SearchTag{{Key: "tagKey", Value: "tagValue"}}
+	cachedJSON, _ := json.Marshal(cachedTags)
+
+	cacheProviderMock := new(CacheProviderMock)
+	cacheProviderMock.On("GetContext", ctx, cacheKey).Return(string(cachedJSON), true)
+
+	delegateMock := new(tags.SearchTagRepositoryMock)
+
+	repository := &RistrettoCachedSearchTagRepository{
+		CacheProvider: cacheProviderMock,
+		Delegate:      delegateMock,
+		logger:        logging.GetLoggerInstanceForComponentByType(&RistrettoCachedSearchTagRepository{}),
+	}
+
+	result, err := repository.GetAllTags(ctx)
+
+	assert.Equal(t, nil, err)
+	assert.Equal(t, cachedTags, result)
+	cacheProviderMock.AssertExpectations(t)
+	delegateMock.AssertNotCalled(t, "GetAllTags", mock.Anything)
+	cacheProviderMock.AssertNotCalled(t, "Get", mock.Anything)
+}
+
+func TestGetAllTagsFetchesFromDelegateAndPopulatesCacheOnCacheMiss(t *testing.T) {
+	ctx := userContextFor("A_USER")
+	cacheKey := "search_tags_user_A_USER"
+	fetchedTags := []tags.SearchTag{{Key: "tagKey", Value: "tagValue"}}
+	fetchedJSON, _ := json.Marshal(fetchedTags)
+
+	cacheProviderMock := new(CacheProviderMock)
+	cacheProviderMock.On("GetContext", ctx, cacheKey).Return("", false)
+	cacheProviderMock.On("SetContext", ctx, cacheKey, string(fetchedJSON)).Return(nil)
+
+	delegateMock := new(tags.SearchTagRepositoryMock)
+	delegateMock.On("GetAllTags", ctx).Return(fetchedTags, nil)
+
+	repository := &RistrettoCachedSearchTagRepository{
+		CacheProvider: cacheProviderMock,
+		Delegate:      delegateMock,
+		logger:        logging.GetLoggerInstanceForComponentByType(&RistrettoCachedSearchTagRepository{}),
+	}
+
+	result, err := repository.GetAllTags(ctx)
+
+	assert.Equal(t, nil, err)
+	assert.Equal(t, fetchedTags, result)
+	cacheProviderMock.AssertExpectations(t)
+	delegateMock.AssertExpectations(t)
+	cacheProviderMock.AssertNotCalled(t, "Get", mock.Anything)
+	cacheProviderMock.AssertNotCalled(t, "Set", mock.Anything, mock.Anything)
+}


### PR DESCRIPTION
## Summary
- `RistrettoCachedSearchTagRepository` now calls `GetContext`/`SetContext` instead of `Get`/`Set`, threading the `ctx` already available at both call sites (`GetAllTags`, `fetchFromDelegate`).
- Dropped the unused `userName` parameter on the private `getFromTheCache`/`setToTheCache` helpers, and the dead `err != nil` branch in `setToTheCache` (`SetContext`/`Set` always return `nil` under the cache's fail-open contract).
- budget-api is the only consumer of `cache.CacheProvider` outside `core-services/golang-web-framework` itself, so this removes the last blocker to a follow-up that deletes the non-context `Get`/`Set`/`Evict` methods from the interface (tracked as a separate issue once this merges).

## Test plan
- [x] `go test -tags test ./adapter/tags/...` — new unit test covers cache hit (no delegate call) and cache miss (delegate called, cache populated via `SetContext`) paths, asserting `Get`/`Set` are never called
- [x] `go test -tags test ./domain/... ./web/... ./adapter/tags/...` — full unit suite green
- [x] `go build` and `go vet -tags test ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)