### PR TITLE
tag-api: remove unused TagRepository.GetTagBy

### DIFF
--- a/tagging/tag-api/adapter/dynamodb/repository.go
+++ b/tagging/tag-api/adapter/dynamodb/repository.go
@@ -2,7 +2,6 @@ package dynamodb
 
 import (
 	"context"
-	"errors"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	aws_config "github.com/aws/aws-sdk-go-v2/config"
@@ -80,38 +79,6 @@ func scopeFrom(item map[string]types.AttributeValue) string {
 		return attr.Value
 	}
 	return ""
-}
-
-func (r *TagDynamoDBRepository) GetTagBy(ctx context.Context, key string) (*domain.Tag, error) {
-	// Implementation for retrieving a tag by key from DynamoDB
-	user, err := security.GetCurrentUser(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	input := &dynamodb.QueryInput{
-		TableName: aws.String(r.TableName),
-		ExpressionAttributeValues: map[string]types.AttributeValue{
-			":user_name":      &types.AttributeValueMemberS{Value: *user.UserName},
-			":search_tag_key": &types.AttributeValueMemberS{Value: key},
-		},
-		KeyConditionExpression: aws.String("user_name =:user_name AND search_tag_key =:search_tag_key"),
-	}
-	result, err := r.Client.Query(ctx, input)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(result.Items) == 0 {
-		return nil, errors.New("tag not found") // Tag not found
-	}
-
-	item := result.Items[0]
-	return &domain.Tag{
-		Key:   item["search_tag_key"].(*types.AttributeValueMemberS).Value,
-		Value: item["search_tag_value"].(*types.AttributeValueMemberS).Value,
-		Scope: scopeFrom(item),
-	}, nil
 }
 
 // FindAllTags queries by user_name. An empty scope means "no filter, return

--- a/tagging/tag-api/adapter/dynamodb/repository_test.go
+++ b/tagging/tag-api/adapter/dynamodb/repository_test.go
@@ -104,6 +104,15 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
+func findTagByKey(tags []domain.Tag, key string) *domain.Tag {
+	for _, tag := range tags {
+		if tag.Key == key {
+			return &tag
+		}
+	}
+	return nil
+}
+
 func saveATag(t *testing.T) {
 	repo := newTagDynamoDBRepository()
 	tag := domain.Tag{Key: "exampleKey", Value: "exampleValue"}
@@ -111,20 +120,6 @@ func saveATag(t *testing.T) {
 	err := repo.SaveTag(newStubbedContext(), &tag)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
-	}
-}
-
-func TestSaveTag(t *testing.T) {
-	saveATag(t)
-	repo := newTagDynamoDBRepository()
-	key := "exampleKey"
-
-	tag, err := repo.GetTagBy(newStubbedContext(), key)
-	if err != nil {
-		t.Errorf("Expected no error, got %v", err)
-	}
-	if tag.Key != key {
-		t.Errorf("Expected key %v, got %v", key, tag.Key)
 	}
 }
 
@@ -150,9 +145,13 @@ func TestSaveTagPersistsNormalizedScope(t *testing.T) {
 		t.Errorf("Expected no error, got %v", err)
 	}
 
-	got, err := repo.GetTagBy(newStubbedContext(), "scopedKey")
+	tags, err := repo.FindAllTags(newStubbedContext(), "")
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
+	}
+	got := findTagByKey(tags, "scopedKey")
+	if got == nil {
+		t.Fatalf("Expected to find tag with key %q, got %+v", "scopedKey", tags)
 	}
 	if got.Scope != "expense" {
 		t.Errorf("Expected normalized scope %q, got %q", "expense", got.Scope)
@@ -167,9 +166,13 @@ func TestSaveTagWithoutScopePersistsEmptyStringScopeAttribute(t *testing.T) {
 		t.Errorf("Expected no error, got %v", err)
 	}
 
-	got, err := repo.GetTagBy(newStubbedContext(), "unscopedKey")
+	tags, err := repo.FindAllTags(newStubbedContext(), "")
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
+	}
+	got := findTagByKey(tags, "unscopedKey")
+	if got == nil {
+		t.Fatalf("Expected to find tag with key %q, got %+v", "unscopedKey", tags)
 	}
 	if got.Scope != "" {
 		t.Errorf("Expected empty scope for unscoped tag, got %q", got.Scope)

--- a/tagging/tag-api/docs/adr/0005-remove-unused-get-tag-by.md
+++ b/tagging/tag-api/docs/adr/0005-remove-unused-get-tag-by.md
@@ -1,0 +1,12 @@
+# Remove TagRepository.GetTagBy instead of deprecating it in place
+
+`GetTagBy(ctx, key)` has been on `domain.TagRepository` since the original scaffold and was never wired into a use case or HTTP route — `FindAllTags` is the only action that exists, and tag-api exposes no per-key route. Its only callers were tests and interface-satisfaction mocks. Two of those tests (`TestSaveTagPersistsNormalizedScope`, `TestSaveTagWithoutScopePersistsEmptyStringScopeAttribute`) used it as their read path to assert on Scope-persistence behavior from [0003](./0003-scope-always-persisted-empty-string-default.md); they were rewritten to assert via `FindAllTags` instead, which is the method actually wired to production.
+
+We deleted the method rather than keeping it deprecated-in-place: it has zero callers, git history is the recovery path if a per-key lookup is ever needed, and budget-api's own `GetTagBy` (a different, used method on a different interface) already covers single-tag lookup by fetching `GET /api/tags` and filtering client-side — so there's no latent cross-service need for a per-key endpoint on tag-api today.
+
+See https://github.com/mrFlick72/onlyone-portal/issues/15.
+
+## Considered Options
+
+- Keep `GetTagBy`, mark deprecated via doc comment — rejected: dead code with no callers and no scheduled consumer; a deprecation comment just defers the same deletion decision.
+- Delete outright (chosen) — no production caller, no cross-service dependency, fully recoverable from git history if needed later.

--- a/tagging/tag-api/domain/action_test.go
+++ b/tagging/tag-api/domain/action_test.go
@@ -16,8 +16,6 @@ type findAllTagsMockRepo struct {
 
 func (m *findAllTagsMockRepo) SaveTag(ctx context.Context, tag *Tag) error { return nil }
 
-func (m *findAllTagsMockRepo) GetTagBy(ctx context.Context, key string) (*Tag, error) { return nil, nil }
-
 func (m *findAllTagsMockRepo) FindAllTags(ctx context.Context, scope string) ([]Tag, error) {
 	m.receivedScope = scope
 	return m.tags, m.err

--- a/tagging/tag-api/domain/tags.go
+++ b/tagging/tag-api/domain/tags.go
@@ -19,7 +19,6 @@ func NormalizeScope(scope string) string {
 
 type TagRepository interface {
 	SaveTag(ctx context.Context, tag *Tag) error
-	GetTagBy(ctx context.Context, key string) (*Tag, error)
 	// FindAllTags returns the user's tags. An empty scope returns every tag
 	// unfiltered; a non-empty scope returns only tags whose normalized Scope
 	// matches it.

--- a/tagging/tag-api/web/api/endpoint_test.go
+++ b/tagging/tag-api/web/api/endpoint_test.go
@@ -107,15 +107,6 @@ func (m *MockRepo) SaveTag(ctx context.Context, tag *domain.Tag) error {
 	return nil
 }
 
-func (m *MockRepo) GetTagBy(ctx context.Context, key string) (*domain.Tag, error) {
-	for _, t := range m.tags {
-		if t.Key == key {
-			return &t, nil
-		}
-	}
-	return nil, nil
-}
-
 func (m *MockRepo) FindAllTags(ctx context.Context, scope string) ([]domain.Tag, error) {
 	if scope == "" {
 		return m.tags, nil


### PR DESCRIPTION
## Summary
- `TagRepository.GetTagBy` had no production caller since the original scaffold commit — `FindAllTags` is the only wired use case, and tag-api exposes no per-key HTTP route. Removed the interface method, the DynamoDB implementation, and the now-orphaned `errors` import.
- The two tests that used `GetTagBy` as their read path for Scope-persistence assertions (`TestSaveTagPersistsNormalizedScope`, `TestSaveTagWithoutScopePersistsEmptyStringScopeAttribute`) were rewritten to verify via `FindAllTags` instead, preserving coverage for the documented Scope-persistence behavior (ADR 0003).
- Dropped the dead `GetTagBy` stubs from `findAllTagsMockRepo` and `MockRepo` test doubles.

Closes #15. See `tagging/tag-api/docs/adr/0005-remove-unused-get-tag-by.md` for the rationale.

## Test plan
- [x] `go build ./...`
- [x] `go vet -tags test ./...`
- [x] `go test -tags test ./domain/... ./web/...`
- [x] `go test -tags test ./adapter/dynamodb/...` against LocalStack (DynamoDB) — all pass, including the two rewritten tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9WRJJSuYrfgcbrrZ3TYrD