### PR TITLE
refactor: prefer type over interface for frontend object shapes (#24)

### DIFF
--- a/portal/application-shell/CLAUDE.md
+++ b/portal/application-shell/CLAUDE.md
@@ -8,6 +8,10 @@ The frontend SPA for OnlyOne Portal — a React 19 + TypeScript multi-page appli
 
 Use the local `typescript-expert`, `typescript-react-reviewer`, or `vercel-react-best-practices` skills when a change touches TypeScript/React behavior or performance. Use Context7/MUI documentation tools when current library details are needed.
 
+## Conventions
+
+- **Object shapes use `type`, not `interface`.** Declare component `Props`, domain models, and other object shapes as `type X = { … }`. Reserve `interface` for the two cases it earns: declaration merging, or extending a third-party `interface`. This is not yet lint-enforced (the frontend has no linter — only `tsc --noEmit`), so apply it by hand. See `docs/adr/0001-prefer-type-over-interface-for-object-shapes.md`.
+
 ## Tech Stack
 
 | Concern | Choice |

--- a/portal/application-shell/docs/adr/0001-prefer-type-over-interface-for-object-shapes.md
+++ b/portal/application-shell/docs/adr/0001-prefer-type-over-interface-for-object-shapes.md
@@ -1,0 +1,37 @@
+# 0001 — Prefer `type` over `interface` for object shapes
+
+- Status: Accepted
+- Date: 2026-06-22
+
+## Context
+
+The frontend declares object shapes — component `Props`, domain models, message bundles, select options — inconsistently. A survey of `src/` found the split roughly even: **32** files declare props with `interface XProps {…}` and **22** with `type XProps = {…}`. The non-props layer already leans `type`: domain models (`BudgetExpense`, `BudgetRevenue`), the message-bundle types, and `SelectOption` are all `type` aliases. So the inconsistency is concentrated in component props, where both forms appear with no rule deciding which.
+
+`interface` and `type` are interchangeable for plain object shapes. `interface` offers two things `type` does not:
+
+- **Declaration merging** — re-opening an interface by re-declaring it.
+- **`extends`** — though `type` expresses the same via intersection (`A & B`).
+
+A survey of our own code found that **neither is used**: no `…Props` interface `extends` anything, and there is no declaration merging anywhere in `src/`. The historical counter-argument for `interface` — marginally better type-checker caching and error messages for large/deep object hierarchies — does not apply to small component-props objects.
+
+## Decision
+
+**`type` is the default for object shapes in the frontend.**
+
+- Declare component `Props`, domain models, and other object shapes as `type X = { … }`.
+- `interface` is reserved for the two cases where it earns its keep:
+  1. **Declaration merging** is genuinely needed (e.g. augmenting a global or a third-party module).
+  2. **Extending a third-party `interface`** that is itself exported as an `interface` (so `extends` reads naturally against the upstream type).
+- Everything else uses `type`. Unions and intersections (e.g. `MenuItemProps & { scope?: TagScope }`) are expressed directly, which `type` handles uniformly and `interface` cannot.
+
+All existing `interface` object shapes are converted to `type` in one standalone, behavior-preserving change (nothing `extends`/merges, so the transform is mechanical), validated by `tsc --noEmit` and the production build.
+
+## Why not keep both / standardize on `interface`
+
+- **Both (status quo)** — rejected: the even 32/22 split is exactly the inconsistency this resolves; "either is fine" is what produced it.
+- **Standardize on `interface`** — rejected: it would fight the union/intersection props the codebase already has, contradict the `type`-based domain/bundle layer, and buy nothing, since the interface-only features (merging, `extends`) are unused here.
+- **`type` (chosen)** — one rule, consistent with the existing non-props layer, no loss of any capability we actually use, and no accidental declaration merging.
+
+## Enforcement (deferred)
+
+This ADR is **documentation-enforced only** at acceptance. There is no linter in the frontend today (only `tsc --noEmit`), so nothing automatically prevents a stray `interface …Props` from reappearing — there is a known drift window. Introducing ESLint with `@typescript-eslint/consistent-type-definitions: ['error', 'type']` (whose `--fix` would also have performed this conversion) is tracked as a separate follow-up, deliberately kept out of this change so a convention codemod does not smuggle in a from-scratch linting toolchain and a broader ruleset decision.

--- a/portal/application-shell/src/analytics/AnalyticsDashboardPage.tsx
+++ b/portal/application-shell/src/analytics/AnalyticsDashboardPage.tsx
@@ -14,7 +14,7 @@ import AnalyticBarChart from "./charts/AnalyticBarChart"
 
 const MAX_YEAR_RANGE_SIZE = 20
 
-interface AnalyticsDashboardPageProps {
+type AnalyticsDashboardPageProps = {
     messageRegistry: MessageBundle
 }
 

--- a/portal/application-shell/src/budget/expense/BudgetExpensePage.tsx
+++ b/portal/application-shell/src/budget/expense/BudgetExpensePage.tsx
@@ -33,7 +33,7 @@ import type { Month } from "../../time/months"
 import type { BudgetExpense, SavedBudgetExpense, SpentBudget } from "./domain/BudgetExpense"
 import { MessageBundle } from "../../messages/MessageRepository";
 
-interface BudgetExpensePageProps {
+type BudgetExpensePageProps = {
     messageRegistry: MessageBundle
 }
 

--- a/portal/application-shell/src/budget/revenue/BudgetRevenueContent.tsx
+++ b/portal/application-shell/src/budget/revenue/BudgetRevenueContent.tsx
@@ -4,7 +4,7 @@ import { Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow
 import BudgetRevenue from "./domain/BudgetRevenue";
 import { BudgetRevenueTableMessageBundle } from "../../messages/MessageBundles";
 
-interface BudgetRevenueTableProps {
+type BudgetRevenueTableProps = {
     revenues: BudgetRevenue[];
     total: string;
     openDeletePopUp: (revenue: BudgetRevenue) => void;

--- a/portal/application-shell/src/budget/revenue/BudgetRevenueForm.tsx
+++ b/portal/application-shell/src/budget/revenue/BudgetRevenueForm.tsx
@@ -10,14 +10,14 @@ import FormSelect, { SelectOption } from "../../components/form/FormSelect";
 import FormTextArea from "../../components/form/FormTextArea";
 import { BudgetRevenueFormMessageBundle } from "../../messages/MessageBundles";
 
-interface BudgetRevenueFormData {
+type BudgetRevenueFormData = {
     date: string;
     amount: string;
     note: string;
     searchTags: SelectOption[];
 }
 
-interface BudgetRevenueFormProps {
+type BudgetRevenueFormProps = {
     budgetRevenueData: BudgetRevenueFormData;
     budgetRevenueHandlers: {
         date: (date: moment.Moment) => void;

--- a/portal/application-shell/src/budget/revenue/BudgetRevenuePage.tsx
+++ b/portal/application-shell/src/budget/revenue/BudgetRevenuePage.tsx
@@ -20,7 +20,7 @@ import BudgetRevenue from "./domain/BudgetRevenue";
 import UploadAttachmentPopUp from "../attachment/UploadAttachmentPopUp";
 import type { AttachmentTarget } from "../attachment/domain/Attachment";
 import { MessageBundle } from "../../messages/MessageRepository";
-interface BudgetRevenuePageProps {
+type BudgetRevenuePageProps = {
     messageRegistry: MessageBundle;
 }
 

--- a/portal/application-shell/src/budget/revenue/BudgetRevenueRow.tsx
+++ b/portal/application-shell/src/budget/revenue/BudgetRevenueRow.tsx
@@ -5,7 +5,7 @@ import { v1 as uuidv1 } from "uuid";
 import BudgetRevenue from "./domain/BudgetRevenue";
 import { BudgetActionsMessageBundle } from "../../messages/MessageBundles";
 
-interface BudgetRevenueRowProps {
+type BudgetRevenueRowProps = {
     revenue: BudgetRevenue
     openDeletePopUp: () => void;
     openUpdatePopUp: () => void;

--- a/portal/application-shell/src/budget/revenue/DeleteBudgetRevenueConfirmationPopUp.tsx
+++ b/portal/application-shell/src/budget/revenue/DeleteBudgetRevenueConfirmationPopUp.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import ConfirmationPopUp from "../../components/layout/ConfirmationPopUp";
 import { DeleteModalMessageBundle } from "../../messages/MessageBundles";
 
-interface DeleteBudgetRevenueConfirmationPopUpProps {
+type DeleteBudgetRevenueConfirmationPopUpProps = {
     saveCallback: () => void;
     modal: DeleteModalMessageBundle;
     open: boolean;

--- a/portal/application-shell/src/budget/revenue/SaveBudgetRevenuePopUp.tsx
+++ b/portal/application-shell/src/budget/revenue/SaveBudgetRevenuePopUp.tsx
@@ -7,7 +7,7 @@ import { SelectOption } from "../../components/form/FormSelect";
 import { AddShoppingCart } from "@mui/icons-material";
 import { BudgetRevenueFormMessageBundle, SaveModalMessageBundle } from "../../messages/MessageBundles";
 
-interface SaveBudgetRevenuePopUpProps {
+type SaveBudgetRevenuePopUpProps = {
     budgetRevenue: {
         date: string;
         amount: string;

--- a/portal/application-shell/src/budget/search-tags/ScopedTagManager.tsx
+++ b/portal/application-shell/src/budget/search-tags/ScopedTagManager.tsx
@@ -6,7 +6,7 @@ import { getSearchTagRegistry, saveSearchTag, TagScope, UNKNOWN_SENTINEL_KEY } f
 import Separator from "../../components/form/Separator";
 import { SearchTagFormMessageBundle, SearchTagsTableMessageBundle } from '../../messages/MessageBundles';
 
-interface ScopedTagManagerProps {
+type ScopedTagManagerProps = {
     scope: TagScope;
     formMessages: SearchTagFormMessageBundle;
     tableMessages: SearchTagsTableMessageBundle;

--- a/portal/application-shell/src/budget/search-tags/SearchTagsForm.tsx
+++ b/portal/application-shell/src/budget/search-tags/SearchTagsForm.tsx
@@ -3,7 +3,7 @@ import FormInputTextField from "../../components/form/FormInputTextField";
 import FormButton from "../../components/form/FormButton";
 import { SearchTagFormMessageBundle } from "../../messages/MessageBundles";
 
-interface SearchTagFormProps {
+type SearchTagFormProps = {
     searchTag: SearchTag;
     handler: any;
     messages: SearchTagFormMessageBundle;

--- a/portal/application-shell/src/budget/search-tags/SearchTagsPage.tsx
+++ b/portal/application-shell/src/budget/search-tags/SearchTagsPage.tsx
@@ -8,7 +8,7 @@ import ScopedTagManager from "./ScopedTagManager";
 import { TagScope } from "./domain/SearchTagRepository";
 import { MessageBundle } from '../../messages/MessageRepository';
 
-interface SearchTagsPageProps {
+type SearchTagsPageProps = {
     messageRegistry: MessageBundle;
 }
 

--- a/portal/application-shell/src/budget/search-tags/SearchTagsTable.tsx
+++ b/portal/application-shell/src/budget/search-tags/SearchTagsTable.tsx
@@ -4,7 +4,7 @@ import FormButton from "../../components/form/FormButton";
 import { FC } from "react";
 import { SearchTagsTableMessageBundle } from "../../messages/MessageBundles";
 
-interface SearchTagsTableProps {
+type SearchTagsTableProps = {
     searchTagsRegistry: SearchTag[];
     handler: (searchTagKey: string, searchTagValue: string) => void;
     messages: SearchTagsTableMessageBundle;

--- a/portal/application-shell/src/components/form/FormButton.tsx
+++ b/portal/application-shell/src/components/form/FormButton.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Button, Grid } from "@mui/material";
 import { commonStyle } from "../../theme/ThemeProvider";
 
-interface FormButtonProps {
+type FormButtonProps = {
     labelPrefix?: React.ReactNode,
     label: string,
     type: "button" | "submit" | "reset",

--- a/portal/application-shell/src/components/form/FormDatePicker.tsx
+++ b/portal/application-shell/src/components/form/FormDatePicker.tsx
@@ -6,7 +6,7 @@ import {LocalizationProvider} from '@mui/x-date-pickers/LocalizationProvider';
 import {commonStyle} from "../../theme/ThemeProvider";
 import moment from "moment";
 
-interface FormDatePickerProps {
+type FormDatePickerProps = {
     label: string
     value: string
     onClickHandler: (value: any) => void

--- a/portal/application-shell/src/components/form/FormInputTextField.tsx
+++ b/portal/application-shell/src/components/form/FormInputTextField.tsx
@@ -2,7 +2,7 @@ import { Grid, TextField } from "@mui/material";
 import React from "react";
 import { commonStyle } from "../../theme/ThemeProvider";
 
-interface FormInputTextFieldProps {
+type FormInputTextFieldProps = {
     id: string,
     label: string,
     type?: string,

--- a/portal/application-shell/src/components/form/FormSelect.tsx
+++ b/portal/application-shell/src/components/form/FormSelect.tsx
@@ -5,12 +5,12 @@ import { commonStyle } from "../../theme/ThemeProvider";
 import Select, { GroupBase, OptionsOrGroups } from "react-select";
 import { Grid, InputLabel } from "@mui/material";
 
-export interface SelectOption {
+export type SelectOption = {
     value: string
     label: string
 }
 
-interface FormSelectProps {
+type FormSelectProps = {
     id: string
     label: string
     multi: boolean

--- a/portal/application-shell/src/components/menu/MenuCard.tsx
+++ b/portal/application-shell/src/components/menu/MenuCard.tsx
@@ -10,7 +10,7 @@ const classes = {
     }
 }
 
-interface MenuCardProps {
+type MenuCardProps = {
     title?: string
     content: any
     linkTo: string

--- a/portal/application-shell/src/components/menu/MenuCardContainer.tsx
+++ b/portal/application-shell/src/components/menu/MenuCardContainer.tsx
@@ -2,7 +2,7 @@ import React, {ReactNode} from 'react';
 import {Grid} from "@mui/material";
 
 
-interface MenuCardContainerProps {
+type MenuCardContainerProps = {
     children: ReactNode
 }
 

--- a/portal/application-shell/src/home/HomePageMenuItem.tsx
+++ b/portal/application-shell/src/home/HomePageMenuItem.tsx
@@ -7,11 +7,11 @@ import { MessageBundle } from '../messages/MessageRepository';
 
 const FONT_SIZE: number = 150
 
-interface HomePageMenuItemWrapperProps {
+type HomePageMenuItemWrapperProps = {
     content: HomePageMenuItemProps
 }
 
-interface HomePageMenuItemProps {
+type HomePageMenuItemProps = {
     titleText: string
     titleIcon: ReactNode
     body: string

--- a/portal/application-shell/src/plan/ChangeTodoStatusPopUp.tsx
+++ b/portal/application-shell/src/plan/ChangeTodoStatusPopUp.tsx
@@ -4,7 +4,7 @@ import { Todo, TodoStatus } from "./domain/Plan";
 import { allowedTransitionsFor, colorFor } from "./domain/TodoStatus";
 import { ChangeTodoStatusModalMessageBundle, TodoStatusMessageBundle } from "../messages/MessageBundles";
 
-interface ChangeTodoStatusPopUpProps {
+type ChangeTodoStatusPopUpProps = {
     open: boolean;
     todo: Todo | null;
     handleClose: () => void;

--- a/portal/application-shell/src/plan/DeletePlanConfirmationPopUp.tsx
+++ b/portal/application-shell/src/plan/DeletePlanConfirmationPopUp.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import ConfirmationPopUp from "../components/layout/ConfirmationPopUp";
 import { DeleteModalMessageBundle } from "../messages/MessageBundles";
 
-interface DeletePlanConfirmationPopUpProps {
+type DeletePlanConfirmationPopUpProps = {
     open: boolean;
     handleClose: () => void;
     saveCallback: () => void;

--- a/portal/application-shell/src/plan/DeleteTodoConfirmationPopUp.tsx
+++ b/portal/application-shell/src/plan/DeleteTodoConfirmationPopUp.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import ConfirmationPopUp from "../components/layout/ConfirmationPopUp";
 import { DeleteModalMessageBundle } from "../messages/MessageBundles";
 
-interface DeleteTodoConfirmationPopUpProps {
+type DeleteTodoConfirmationPopUpProps = {
     open: boolean;
     handleClose: () => void;
     saveCallback: () => void;

--- a/portal/application-shell/src/plan/PlanDetailPage.tsx
+++ b/portal/application-shell/src/plan/PlanDetailPage.tsx
@@ -16,7 +16,7 @@ import DeleteTodoConfirmationPopUp from "./DeleteTodoConfirmationPopUp";
 import ChangeTodoStatusPopUp from "./ChangeTodoStatusPopUp";
 import { MessageBundle } from "../messages/MessageRepository";
 
-interface PlanDetailPageProps {
+type PlanDetailPageProps = {
     messageRegistry: MessageBundle;
 }
 

--- a/portal/application-shell/src/plan/PlanForm.tsx
+++ b/portal/application-shell/src/plan/PlanForm.tsx
@@ -10,7 +10,7 @@ export type PlanFormData = {
     date: string;
 };
 
-interface PlanFormProps {
+type PlanFormProps = {
     data: PlanFormData;
     handlers: {
         title: (event: React.ChangeEvent<HTMLInputElement>) => void;

--- a/portal/application-shell/src/plan/PlanListContent.tsx
+++ b/portal/application-shell/src/plan/PlanListContent.tsx
@@ -4,7 +4,7 @@ import Plan from "./domain/Plan";
 import PlanListRow from "./PlanListRow";
 import { PlanListContentMessageBundle } from "../messages/MessageBundles";
 
-interface PlanListContentProps {
+type PlanListContentProps = {
     plans: Plan[];
     openDetail: (plan: Plan) => void;
     openDelete: (plan: Plan) => void;

--- a/portal/application-shell/src/plan/PlanListPage.tsx
+++ b/portal/application-shell/src/plan/PlanListPage.tsx
@@ -14,7 +14,7 @@ import SavePlanPopUp from "./SavePlanPopUp";
 import DeletePlanConfirmationPopUp from "./DeletePlanConfirmationPopUp";
 import { MessageBundle } from "../messages/MessageRepository";
 
-interface PlanListPageProps {
+type PlanListPageProps = {
     messageRegistry: MessageBundle;
 }
 

--- a/portal/application-shell/src/plan/PlanListRow.tsx
+++ b/portal/application-shell/src/plan/PlanListRow.tsx
@@ -6,7 +6,7 @@ import Plan from "./domain/Plan";
 import { ApiDateFormatPattern, FormDateFormatPattern } from "../components/form/FormDatePicker";
 import { PlanListRowActionsMessageBundle } from "../messages/MessageBundles";
 
-interface PlanListRowProps {
+type PlanListRowProps = {
     plan: Plan;
     openDetail: () => void;
     openDelete: () => void;

--- a/portal/application-shell/src/plan/SavePlanPopUp.tsx
+++ b/portal/application-shell/src/plan/SavePlanPopUp.tsx
@@ -6,7 +6,7 @@ import PlanForm, { PlanFormData } from "./PlanForm";
 import YesAndNoButtonGroup from "../components/layout/YesAndNoButtonGroup";
 import { PlanFormMessageBundle, SaveModalMessageBundle } from "../messages/MessageBundles";
 
-interface SavePlanPopUpProps {
+type SavePlanPopUpProps = {
     open: boolean;
     handleClose: () => void;
     plan: PlanFormData;

--- a/portal/application-shell/src/plan/SaveTodoPopUp.tsx
+++ b/portal/application-shell/src/plan/SaveTodoPopUp.tsx
@@ -6,7 +6,7 @@ import TodoForm, { TodoFormData } from "./TodoForm";
 import YesAndNoButtonGroup from "../components/layout/YesAndNoButtonGroup";
 import { SaveModalMessageBundle, TodoFormMessageBundle } from "../messages/MessageBundles";
 
-interface SaveTodoPopUpProps {
+type SaveTodoPopUpProps = {
     open: boolean;
     handleClose: () => void;
     todo: TodoFormData;

--- a/portal/application-shell/src/plan/TodoContent.tsx
+++ b/portal/application-shell/src/plan/TodoContent.tsx
@@ -4,7 +4,7 @@ import { Todo } from "./domain/Plan";
 import TodoRow from "./TodoRow";
 import { TodoContentMessageBundle } from "../messages/MessageBundles";
 
-interface TodoContentProps {
+type TodoContentProps = {
     todos: Todo[];
     openUpdate: (todo: Todo) => void;
     openDelete: (todo: Todo) => void;

--- a/portal/application-shell/src/plan/TodoForm.tsx
+++ b/portal/application-shell/src/plan/TodoForm.tsx
@@ -11,7 +11,7 @@ export type TodoFormData = {
     date: string;
 };
 
-interface TodoFormProps {
+type TodoFormProps = {
     data: TodoFormData;
     handlers: {
         content: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;

--- a/portal/application-shell/src/plan/TodoRow.tsx
+++ b/portal/application-shell/src/plan/TodoRow.tsx
@@ -7,7 +7,7 @@ import { ApiDateFormatPattern, FormDateFormatPattern } from "../components/form/
 import { colorFor, isTerminal } from "./domain/TodoStatus";
 import { TodoRowActionsMessageBundle, TodoStatusMessageBundle } from "../messages/MessageBundles";
 
-interface TodoRowProps {
+type TodoRowProps = {
     todo: Todo;
     openUpdate: () => void;
     openDelete: () => void;


### PR DESCRIPTION
Standardizes frontend object shapes on `type`, resolving an even 32/22 `interface`/`type` split in `portal/application-shell/src`. Designed via `/grilling`; see ADR 0001 (added here).

## The rule

`type` is the default for object shapes (props, domain models, bundles). `interface` is reserved for (1) declaration merging or (2) extending a third-party `interface`. Nothing in our code used those interface-only features, so the conversion is purely mechanical and behavior-preserving.

## Changes

- **ADR** `portal/application-shell/docs/adr/0001-prefer-type-over-interface-for-object-shapes.md` (the frontend's first ADR) — rule, escape hatch, the data, and the deferred-enforcement note.
- **`CLAUDE.md`** — a Conventions line pointing at the ADR.
- **Codemod**: 35 conversions across 32 files, each a one-line `interface X {…}` → `type X = {…}` swap.
- **Escape hatch retained**: `vite-env.d.ts` keeps `interface ImportMeta` / `ImportMetaEnv`, which merge into Vite's global `ImportMeta` to type `import.meta.env` — declaration merging needs `interface`.

## Verification

`npm run type-check` and `npm run production-build` both pass. The diff is 35 insertions / 35 deletions of declaration lines plus the two doc files — no behavior changes.

## Out of scope

ESLint enforcement (`@typescript-eslint/consistent-type-definitions`) is tracked in #25 — until it lands, the convention is documentation-enforced only.

Closes #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)