### PR TITLE
docs: design tag catalog update/delete (#28)

### DIFF
--- a/budget/budget-api/CONTEXT.md
+++ b/budget/budget-api/CONTEXT.md
@@ -15,3 +15,7 @@ _Avoid_: Uncategorized revenue, default-tagged revenue
 **UnknownSentinel**:
 The single budget-api-side definition of the `UNKNOWN` Sentinel Tag (`tags.UnknownSentinel`), shared by both the expense and revenue default-if-missing helpers so the literal is written once per service. It mirrors the same convention tag-api synthesizes on read; the two services duplicate the string with no shared enforcement (see Tagging context and tag-api ADR 0001).
 _Avoid_: Default tag, fallback tag
+
+**Unresolvable Tag Reference**:
+A stored tag `Key` on an `Untagged Expense`'s or `Untagged Revenue`'s record that no longer exists in tag-api's catalog — today, only because the tag was deleted (tag-api [ADR 0008](../../tagging/tag-api/docs/adr/0008-tag-update-is-value-only.md)). `GetTagBy` resolves it to the same `UnknownSentinel`, in place, at read time: no write touches the record's stored `Key`, and no analytics projection is updated (see [ADR 0003](./docs/adr/0003-deleted-tag-references-resolve-to-unknown-in-place.md)). Indistinguishable downstream from a record that was never tagged — both resolve to `UNKNOWN` the same way. Making the reclassification durable, and reflecting it in analytics, is deferred (#27).
+_Avoid_: Orphaned tag, dangling tag reference

--- a/budget/budget-api/adapter/tags/rest/rest_tags_repository.go
+++ b/budget/budget-api/adapter/tags/rest/rest_tags_repository.go
@@ -39,8 +39,12 @@ func (repository *RestSearchTagRepository) GetTagBy(ctx context.Context, key str
 			return &searchTag, nil
 		}
 	}
-	return nil, fmt.Errorf("tag with key '%s' not found", key)
-
+	// key isn't in the catalog — most likely because the tag was deleted
+	// (tag-api ADR 0008). Degrade to the UNKNOWN sentinel in place rather
+	// than erroring; see
+	// docs/adr/0003-deleted-tag-references-resolve-to-unknown-in-place.md.
+	unknown := tags.UnknownSentinel()
+	return &unknown, nil
 }
 
 func (repository *RestSearchTagRepository) GetAllTags(ctx context.Context) ([]tags.SearchTag, error) {

--- a/budget/budget-api/adapter/tags/rest/rest_tags_repository_test.go
+++ b/budget/budget-api/adapter/tags/rest/rest_tags_repository_test.go
@@ -57,3 +57,18 @@ func TestGetTagByCallsScopedTagEndpointAndFiltersByKey(t *testing.T) {
 	assert.Equal(t, "/api/tags/scope/expense", requestedPath)
 	assert.Equal(t, &tags.SearchTag{Key: "tagKey", Value: "tagValue"}, result)
 }
+
+func TestGetTagByReturnsUnknownSentinelWhenKeyNotInCatalog(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"key":"other","value":"otherValue"}]`))
+	}))
+	defer server.Close()
+
+	repository := NewRestSearchTagRepository(server.Client(), server.URL, "expense")
+
+	result, err := repository.GetTagBy(userContextWithToken("A_USER", "A_TOKEN"), "deletedTagKey")
+
+	assert.Equal(t, nil, err)
+	assert.Equal(t, &tags.SearchTag{Key: "UNKNOWN", Value: "UNKNOWN"}, result)
+}

--- a/budget/budget-api/adapter/tags/rest/ristretto_cached_rest_tags_repositor.go
+++ b/budget/budget-api/adapter/tags/rest/ristretto_cached_rest_tags_repositor.go
@@ -52,7 +52,12 @@ func (repository *RistrettoCachedSearchTagRepository) GetTagBy(ctx context.Conte
 			return &searchTag, nil
 		}
 	}
-	return nil, fmt.Errorf("tag with key '%s' not found", key)
+	// key isn't in the catalog — most likely because the tag was deleted
+	// (tag-api ADR 0008). Degrade to the UNKNOWN sentinel in place rather
+	// than erroring; see
+	// docs/adr/0003-deleted-tag-references-resolve-to-unknown-in-place.md.
+	unknown := tags.UnknownSentinel()
+	return &unknown, nil
 }
 
 func (repository *RistrettoCachedSearchTagRepository) GetAllTags(ctx context.Context) ([]tags.SearchTag, error) {

--- a/budget/budget-api/adapter/tags/rest/ristretto_cached_rest_tags_repositor_test.go
+++ b/budget/budget-api/adapter/tags/rest/ristretto_cached_rest_tags_repositor_test.go
@@ -94,3 +94,28 @@ func TestGetAllTagsFetchesFromDelegateAndPopulatesCacheOnCacheMiss(t *testing.T)
 	cacheProviderMock.AssertNotCalled(t, "Get", mock.Anything)
 	cacheProviderMock.AssertNotCalled(t, "Set", mock.Anything, mock.Anything)
 }
+
+func TestGetTagByReturnsUnknownSentinelWhenKeyNotInCachedCatalog(t *testing.T) {
+	ctx := userContextFor("A_USER")
+	cacheKey := "search_tags_user_A_USER_scope_expense"
+	cachedTags := []tags.SearchTag{{Key: "other", Value: "otherValue"}}
+	cachedJSON, _ := json.Marshal(cachedTags)
+
+	cacheProviderMock := new(CacheProviderMock)
+	cacheProviderMock.On("GetContext", ctx, cacheKey).Return(string(cachedJSON), true)
+
+	delegateMock := new(tags.SearchTagRepositoryMock)
+
+	repository := &RistrettoCachedSearchTagRepository{
+		CacheProvider: cacheProviderMock,
+		Delegate:      delegateMock,
+		Scope:         "expense",
+		logger:        logging.GetLoggerInstanceForComponentByType(&RistrettoCachedSearchTagRepository{}),
+	}
+
+	result, err := repository.GetTagBy(ctx, "deletedTagKey")
+
+	assert.Equal(t, nil, err)
+	assert.Equal(t, &tags.SearchTag{Key: "UNKNOWN", Value: "UNKNOWN"}, result)
+	delegateMock.AssertNotCalled(t, "GetAllTags", mock.Anything)
+}

--- a/budget/budget-api/docs/adr/0003-deleted-tag-references-resolve-to-unknown-in-place.md
+++ b/budget/budget-api/docs/adr/0003-deleted-tag-references-resolve-to-unknown-in-place.md
@@ -1,0 +1,73 @@
+# 0003 — Deleted tag references resolve to UNKNOWN in place, at read time; no migration this iteration
+
+- Status: Accepted
+- Date: 2026-06-23
+
+## Context
+
+tag-api's tag catalog is gaining update and delete (previously create-only; see #28 and tag-api's ADR on value-only
+update). Delete is the hard case for budget-api: both expense and revenue store a tag by **key** only and resolve it
+to its current value live from tag-api on every read (`GetTagBy`, via the Ristretto-cached
+`RestSearchTagRepository` — see this service's ADR 0001/0002). `GetTagBy` today returns an error when a key is not
+found in the scoped catalog.
+
+That error propagates destructively once tags become deletable:
+
+- `DynamoDbBudgetExpenseRepository.fromDynamo` (single read) propagates the error — a request for one expense that
+  references a deleted tag returns `500`.
+- `FindByDateRange`'s loop logs the error and **skips** the record — an expense referencing a deleted tag silently
+  vanishes from list views, and its amount drops out of any total computed over the list.
+- Revenue's equivalent resolution path has the same shape.
+
+So the moment tag-api can delete a tag, every expense/revenue still referencing it breaks — immediately, and
+silently in the list case. Some response to a missing key is required before delete can ship at all.
+
+This service already has a sentinel for exactly this shape of problem: `tags.UnknownSentinel()`
+(`{Key: "UNKNOWN", Value: "UNKNOWN"}`), used today to default a record saved with **no** tags so every record
+resolves to at least one. A deleted-tag reference has a different cause (the record once had a real tag; the
+catalog entry is now gone) but an identical resolution-time symptom: "this key doesn't resolve to a real catalog
+entry right now."
+
+## Decision
+
+`GetTagBy`'s not-found branch returns `tags.UnknownSentinel()` instead of an error, in both
+`RestSearchTagRepository` and `RistrettoCachedSearchTagRepository` (the two implementations duplicate the same
+not-found logic and need the same change). A deleted tag's references therefore read exactly like an untagged
+record — same sentinel, same key — with **no distinction preserved** between "always untagged" and "was tagged,
+the tag was deleted."
+
+This is read-time and in-place only:
+
+- **No write happens.** The expense/revenue record's stored `tag` attribute (the deleted key) is untouched in
+  DynamoDB. Every read re-resolves it to `UNKNOWN` via the same fallback, indefinitely.
+- **No analytics update.** analytic-api's Postgres projection, built from the `budget-api.expense` Kafka stream at
+  the time the expense was created/updated, still reflects whatever tag the expense carried back then. It does not
+  learn about the deletion.
+- Errors that are **not** "key absent from the scoped catalog" — tag-api unreachable, auth failure, malformed
+  response — are untouched and continue to propagate as errors. Only the specific "looked through the whole list,
+  key wasn't in it" branch changes.
+
+A dedicated follow-up (#27) makes the `UNKNOWN` reclassification durable: rewriting the stored `tag` attribute on
+affected records, and firing a Kafka reindex event so analytic-api's projection catches up for the affected month.
+
+## Why not migrate now
+
+- **Locating affected records requires a scan.** Neither the expense nor the revenue DynamoDB key scheme has a GSI
+  on tag key; finding every record referencing a deleted key means a strategy this feature doesn't otherwise need
+  (scan-by-key, or iterate by month/year). Designing that scan, plus the new Kafka reindex event and analytic-api
+  handler, is real, separable scope — see #27.
+- **Read-time fallback is sufficient for correctness today.** Once `GetTagBy` stops erroring, no record is lost
+  from a list and no read 500s. The only thing the migration buys beyond that is no longer needing the
+  fallback — a performance/cleanliness improvement, not a correctness one.
+- **Decoupling ships delete sooner.** Update/delete is useful on its own; gating it on a Kafka reindex pipeline
+  that doesn't exist yet would block a self-contained, low-risk change behind a much larger one.
+
+## Consequences
+
+- A user who deletes a tag sees every expense/revenue that used it immediately show "Uncategorized" (`UNKNOWN`) —
+  non-destructive, but the original tag value is unrecoverable from budget-api once gone from tag-api (tag-api
+  itself does not soft-delete either).
+- Two distinct situations — "this record was never tagged" and "this record's tag was deleted" — are
+  indistinguishable downstream until #27 ships. Acceptable: the UI and analytics never needed to tell them apart.
+- Until #27 lands, the underlying DynamoDB `tag` attribute can reference a tag key that no longer exists in
+  tag-api's catalog — a transient, intentional inconsistency the read-time fallback fully masks.

--- a/core-services/golang-web-framework/middleware/security/jwt_test.go
+++ b/core-services/golang-web-framework/middleware/security/jwt_test.go
@@ -1,6 +1,7 @@
 package security
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -38,8 +39,9 @@ func TestWhenARequestIsAuthorized(t *testing.T) {
 	req.Header.Set("Authorization", testutils.CreateTestToken([]string{"ROLE_USER", "ROLE_ADMIN"}))
 	router.ServeHTTP(w, req)
 
+	expected, _ := json.Marshal(map[string]string{"message": "sample endpoint"})
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "{\"message\":\"sample endpoint\"}", w.Body.String())
+	assert.Equal(t, string(expected), w.Body.String())
 }
 
 func TestWhenARequestIsNoAuthorized(t *testing.T) {

--- a/core-services/golang-web-framework/web/management/health_endpoint_test.go
+++ b/core-services/golang-web-framework/web/management/health_endpoint_test.go
@@ -1,6 +1,7 @@
 package management
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -22,6 +23,7 @@ func TestHealth(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/management/health", nil)
 	router.ServeHTTP(w, req)
 
+	expected, _ := json.Marshal(map[string]string{"status": "UP"})
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "{\"status\":\"UP\"}", w.Body.String())
+	assert.Equal(t, string(expected), w.Body.String())
 }

--- a/core-services/golang-web-framework/web/server/standard_middleware_configurer.go
+++ b/core-services/golang-web-framework/web/server/standard_middleware_configurer.go
@@ -42,7 +42,7 @@ func (c *StandardMiddlewareConfigurer) Dispose(_ context.Context) error {
 func corsConfigurer() gin.HandlerFunc {
 	return cors.New(cors.Config{
 		AllowOrigins:     strings.Split(configurationManager.GetConfigFor("cors.allowed.origins"), ","),
-		AllowMethods:     []string{"GET", "PUT", "POST", "DELETE", "OPTIONS"},
+		AllowMethods:     []string{"GET", "PUT", "POST", "DELETE", "PATCH", "OPTIONS"},
 		AllowHeaders:     []string{"Origin", "Authorization", "Content-Type", "Accept"},
 		AllowCredentials: true,
 		MaxAge:           60 * time.Minute,

--- a/portal/application-shell/src/budget/search-tags/DeleteSearchTagConfirmationPopUp.tsx
+++ b/portal/application-shell/src/budget/search-tags/DeleteSearchTagConfirmationPopUp.tsx
@@ -1,0 +1,23 @@
+import React from "react"
+import ConfirmationPopUp from "../../components/layout/ConfirmationPopUp";
+import { DeleteModalMessageBundle } from "../../messages/MessageBundles";
+
+type DeleteSearchTagConfirmationPopUpProps = {
+    open: boolean;
+    handleClose: () => void;
+    saveCallback: () => void;
+    modal: DeleteModalMessageBundle;
+}
+
+const DeleteSearchTagConfirmationPopUp: React.FC<DeleteSearchTagConfirmationPopUpProps> = ({ open, handleClose, saveCallback, modal }) => (
+    <ConfirmationPopUp
+        open={open}
+        handleClose={handleClose}
+        confirmationHandler={saveCallback}
+        modalTitle={modal.title}
+        modalMessageBody={modal.message}
+        yesLabel={modal.yesLabel}
+        noLabel={modal.noLabel} />
+);
+
+export default DeleteSearchTagConfirmationPopUp;

--- a/portal/application-shell/src/budget/search-tags/ScopedTagManager.tsx
+++ b/portal/application-shell/src/budget/search-tags/ScopedTagManager.tsx
@@ -2,24 +2,41 @@ import React, { FC, useCallback, useEffect, useState } from 'react'
 import { Container } from "@mui/material";
 import SearchTagsTable from "./SearchTagsTable";
 import SearchTagsForm from "./SearchTagsForm";
-import { getSearchTagRegistry, saveSearchTag, TagScope, UNKNOWN_SENTINEL_KEY } from "./domain/SearchTagRepository";
+import UpdateSearchTagPopUp from "./UpdateSearchTagPopUp";
+import DeleteSearchTagConfirmationPopUp from "./DeleteSearchTagConfirmationPopUp";
+import { deleteSearchTag, getSearchTagRegistry, saveSearchTag, TagScope, UNKNOWN_SENTINEL_KEY, updateSearchTagValue } from "./domain/SearchTagRepository";
 import Separator from "../../components/form/Separator";
-import { SearchTagFormMessageBundle, SearchTagsTableMessageBundle } from '../../messages/MessageBundles';
+import { DeleteModalMessageBundle, SaveModalMessageBundle, SearchTagFormMessageBundle, SearchTagsTableMessageBundle } from '../../messages/MessageBundles';
 
 type ScopedTagManagerProps = {
     scope: TagScope;
     formMessages: SearchTagFormMessageBundle;
     tableMessages: SearchTagsTableMessageBundle;
+    editModal: SaveModalMessageBundle;
+    deleteModal: DeleteModalMessageBundle;
 }
+
+const emptySearchTag: SearchTag = { key: "", value: "" }
 
 /**
  * Manages the tag catalog for a single {@link TagScope}: lists the scope's
- * tags and creates new ones. Rendered once per tab (Expense / Revenue), so the
- * two tabs are guaranteed to behave identically — same component, two scopes.
+ * tags, creates new ones, and edits/deletes existing ones. Rendered once per
+ * tab (Expense / Revenue), so the two tabs are guaranteed to behave
+ * identically — same component, two scopes.
  */
-const ScopedTagManager: FC<ScopedTagManagerProps> = ({ scope, formMessages, tableMessages }) => {
+const ScopedTagManager: FC<ScopedTagManagerProps> = ({ scope, formMessages, tableMessages, editModal, deleteModal }) => {
     const [searchTagsRegistry, setSearchTagsRegistry] = useState<SearchTag[]>([])
-    const [searchTag, setSearchTag] = useState<SearchTag>({ key: "", value: "" })
+
+    // The create form always starts empty and resets after every save — it
+    // never reflects a tag selected for editing (that goes through the
+    // dedicated edit popup below).
+    const [newSearchTag, setNewSearchTag] = useState<SearchTag>(emptySearchTag)
+
+    const [editingSearchTag, setEditingSearchTag] = useState<SearchTag>(emptySearchTag)
+    const [openEditPopUp, setOpenEditPopUp] = useState(false)
+
+    const [deletingSearchTag, setDeletingSearchTag] = useState<SearchTag>(emptySearchTag)
+    const [openDeletePopUp, setOpenDeletePopUp] = useState(false)
 
     // Load the scope's catalog, hiding the UNKNOWN technical sentinel — this is
     // a catalog editor, not a tag selector, so the non-persisted catch-all has
@@ -33,24 +50,56 @@ const ScopedTagManager: FC<ScopedTagManagerProps> = ({ scope, formMessages, tabl
 
     const formHandler = {
         valueHandler: (value: React.ChangeEvent<HTMLInputElement>) => {
-            setSearchTag((prevState) => ({
+            setNewSearchTag((prevState) => ({
                 ...prevState,
                 value: value.target.value
             }))
         },
-        submitHandler: (searchTagKey: string, searchTagValue: string) => {
-            saveSearchTag({ key: searchTagKey, value: searchTagValue }, scope)
-                .then(() => loadRegistry())
+        submitHandler: (_searchTagKey: string, searchTagValue: string) => {
+            saveSearchTag({ key: "", value: searchTagValue }, scope)
+                .then(() => {
+                    setNewSearchTag(emptySearchTag)
+                    loadRegistry()
+                })
         }
     }
 
-    const tableHandler = (searchTagKey: string, searchTagValue: string) => {
-        setSearchTag({ key: searchTagKey, value: searchTagValue })
+    const editValueHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setEditingSearchTag((prevState) => ({
+            ...prevState,
+            value: event.target.value
+        }))
+    }
+
+    const openEdit = (searchTag: SearchTag) => {
+        setEditingSearchTag(searchTag)
+        setOpenEditPopUp(true)
+    }
+    const closeEdit = () => setOpenEditPopUp(false)
+    const saveEdit = () => {
+        updateSearchTagValue(editingSearchTag.key, editingSearchTag.value, scope)
+            .then(() => {
+                setOpenEditPopUp(false)
+                loadRegistry()
+            })
+    }
+
+    const openDelete = (searchTag: SearchTag) => {
+        setDeletingSearchTag(searchTag)
+        setOpenDeletePopUp(true)
+    }
+    const closeDelete = () => setOpenDeletePopUp(false)
+    const confirmDelete = () => {
+        deleteSearchTag(deletingSearchTag.key, scope)
+            .then(() => {
+                setOpenDeletePopUp(false)
+                loadRegistry()
+            })
     }
 
     return <Container>
         <SearchTagsForm
-            searchTag={{ key: searchTag.key, value: searchTag.value }}
+            searchTag={newSearchTag}
             handler={formHandler}
             messages={formMessages} />
 
@@ -58,8 +107,23 @@ const ScopedTagManager: FC<ScopedTagManagerProps> = ({ scope, formMessages, tabl
 
         <SearchTagsTable
             searchTagsRegistry={searchTagsRegistry}
-            handler={tableHandler}
+            handler={{ onEdit: openEdit, onDelete: openDelete }}
             messages={tableMessages} />
+
+        <UpdateSearchTagPopUp
+            open={openEditPopUp}
+            handleClose={closeEdit}
+            value={editingSearchTag.value}
+            valueHandler={editValueHandler}
+            saveCallback={saveEdit}
+            modal={editModal}
+            formMessages={formMessages} />
+
+        <DeleteSearchTagConfirmationPopUp
+            open={openDeletePopUp}
+            handleClose={closeDelete}
+            saveCallback={confirmDelete}
+            modal={deleteModal} />
     </Container>
 }
 

--- a/portal/application-shell/src/budget/search-tags/SearchTagsPage.tsx
+++ b/portal/application-shell/src/budget/search-tags/SearchTagsPage.tsx
@@ -28,7 +28,11 @@ const SearchTagsPage: FC<SearchTagsPageProps> = ({ messageRegistry }) => {
     const messages = configMap.searchTags(messageRegistry)
     const tableMessages = {
         description: configMap.common(messageRegistry).table.description,
-        operation: configMap.common(messageRegistry).table.operation
+        operation: configMap.common(messageRegistry).table.operation,
+        actions: {
+            edit: configMap.common(messageRegistry).action.edit,
+            delete: configMap.common(messageRegistry).action.delete
+        }
     }
 
     const [tabPanel, setTabPanel] = useState<number>(initialTabFromQuery)
@@ -64,7 +68,9 @@ const SearchTagsPage: FC<SearchTagsPageProps> = ({ messageRegistry }) => {
                             <ScopedTagManager
                                 scope={scope}
                                 formMessages={messages.form}
-                                tableMessages={tableMessages} />
+                                tableMessages={tableMessages}
+                                editModal={messages.editSearchTagModal}
+                                deleteModal={messages.deleteSearchTagModal} />
                         </TabPanel>
                     ))}
                 </Box>

--- a/portal/application-shell/src/budget/search-tags/SearchTagsTable.tsx
+++ b/portal/application-shell/src/budget/search-tags/SearchTagsTable.tsx
@@ -1,12 +1,14 @@
-import { Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from "@mui/material";
-import { ModeEdit } from "@mui/icons-material";
-import FormButton from "../../components/form/FormButton";
+import { Button, ButtonGroup, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from "@mui/material";
+import { Delete, Edit } from "@mui/icons-material";
 import { FC } from "react";
 import { SearchTagsTableMessageBundle } from "../../messages/MessageBundles";
 
 type SearchTagsTableProps = {
     searchTagsRegistry: SearchTag[];
-    handler: (searchTagKey: string, searchTagValue: string) => void;
+    handler: {
+        onEdit: (searchTag: SearchTag) => void;
+        onDelete: (searchTag: SearchTag) => void;
+    };
     messages: SearchTagsTableMessageBundle;
 }
 
@@ -26,11 +28,10 @@ const SearchTagsTable: FC<SearchTagsTableProps> = ({ searchTagsRegistry, handler
                             {searchTag.value}
                         </TableCell>
                         <TableCell>
-                            <FormButton type="button"
-                                label=""
-                                labelPrefix={<ModeEdit />}
-                                onClickHandler={() => handler(searchTag.key, searchTag.value)}
-                            />
+                            <ButtonGroup variant="contained" aria-label="outlined primary button group">
+                                <Button onClick={() => handler.onEdit(searchTag)}><Edit /> {messages.actions.edit}</Button>
+                                <Button onClick={() => handler.onDelete(searchTag)}><Delete /> {messages.actions.delete}</Button>
+                            </ButtonGroup>
                         </TableCell>
                     </TableRow>
                 ))}

--- a/portal/application-shell/src/budget/search-tags/UpdateSearchTagPopUp.tsx
+++ b/portal/application-shell/src/budget/search-tags/UpdateSearchTagPopUp.tsx
@@ -1,0 +1,45 @@
+import React from "react"
+import { Dialog, DialogActions, DialogContent, DialogTitle } from "@mui/material";
+import { Check } from "@mui/icons-material";
+import FormInputTextField from "../../components/form/FormInputTextField";
+import YesAndNoButtonGroup from "../../components/layout/YesAndNoButtonGroup";
+import { SaveModalMessageBundle, SearchTagFormMessageBundle } from "../../messages/MessageBundles";
+
+type UpdateSearchTagPopUpProps = {
+    open: boolean;
+    handleClose: () => void;
+    value: string;
+    valueHandler: (event: React.ChangeEvent<HTMLInputElement>) => void;
+    saveCallback: () => void;
+    modal: SaveModalMessageBundle;
+    formMessages: SearchTagFormMessageBundle;
+}
+
+// Edit is value-only: Key and Scope are immutable once a tag exists (see
+// tag-api docs/adr/0008-tag-update-is-value-only.md), and Scope is already
+// intrinsic to the tab the user is on, so neither is shown here.
+const UpdateSearchTagPopUp: React.FC<UpdateSearchTagPopUpProps> = ({ open, handleClose, value, valueHandler, saveCallback, modal, formMessages }) => (
+    <Dialog onClose={handleClose} open={open} fullWidth scroll="paper">
+        <DialogTitle>{modal.title}</DialogTitle>
+        <DialogContent>
+            <FormInputTextField
+                handler={valueHandler}
+                autoFocus={true}
+                value={value}
+                id="updateSearchTagValue"
+                label={formMessages.valueLabel} />
+        </DialogContent>
+        <DialogActions>
+            <YesAndNoButtonGroup
+                yesIcon={<Check />}
+                yesFun={saveCallback}
+                noFun={handleClose}
+                buttonMessages={{
+                    noLabel: modal.closeButtonLabel,
+                    yesLabel: modal.saveButtonLabel,
+                }} />
+        </DialogActions>
+    </Dialog>
+);
+
+export default UpdateSearchTagPopUp;

--- a/portal/application-shell/src/budget/search-tags/domain/SearchTagRepository.ts
+++ b/portal/application-shell/src/budget/search-tags/domain/SearchTagRepository.ts
@@ -45,3 +45,31 @@ export async function saveSearchTag(searchTag: SearchTag, scope: TagScope): Prom
     });
     return Promise.resolve();
 }
+
+// updateSearchTagValue changes only the Value of an existing tag — Key and
+// Scope are immutable once a tag exists (tag-api ADR 0008).
+export async function updateSearchTagValue(key: string, value: string, scope: TagScope): Promise<void> {
+    const baseUrl = await getTagApiBaseUrl();
+    await fetch(`${baseUrl}/api/tags/scope/${scope}/${key}`, {
+        method: "PATCH",
+        credentials: "same-origin",
+        body: JSON.stringify({ "value": value }),
+        headers: {
+            Authorization: `Bearer ${window.sessionStorage.getItem("ACCESS_TOKEN")}`,
+            "Content-Type": "application/json",
+        },
+    });
+    return Promise.resolve();
+}
+
+export async function deleteSearchTag(key: string, scope: TagScope): Promise<void> {
+    const baseUrl = await getTagApiBaseUrl();
+    await fetch(`${baseUrl}/api/tags/scope/${scope}/${key}`, {
+        method: "DELETE",
+        credentials: "same-origin",
+        headers: {
+            Authorization: `Bearer ${window.sessionStorage.getItem("ACCESS_TOKEN")}`,
+        },
+    });
+    return Promise.resolve();
+}

--- a/portal/application-shell/src/messages/MessageBundles.ts
+++ b/portal/application-shell/src/messages/MessageBundles.ts
@@ -98,7 +98,7 @@ export type SearchTagFormMessageBundle = { valueLabel: string; saveLabel: string
 /** Localized label per todo status, keyed by the {@link TodoStatus} union. */
 export type TodoStatusMessageBundle = Record<TodoStatus, string>;
 
-export type SearchTagsTableMessageBundle = { description: string; operation: string };
+export type SearchTagsTableMessageBundle = { description: string; operation: string; actions: { edit: string; delete: string } };
 export type TotalBySearchTagsMessageBundle = { category: string; total: string };
 
 export type PlanListRowActionsMessageBundle = { open: string; delete: string };
@@ -204,6 +204,8 @@ export type SearchTagsPageMessageBundle = {
     heading: string;
     tabs: SearchTagsTabsMessageBundle;
     form: SearchTagFormMessageBundle;
+    editSearchTagModal: WithId<SaveModalMessageBundle>;
+    deleteSearchTagModal: WithId<DeleteModalMessageBundle>;
 };
 
 export type PlanPageMessageBundle = {

--- a/portal/application-shell/src/messages/OnlyonePortalPagesConfigMap.tsx
+++ b/portal/application-shell/src/messages/OnlyonePortalPagesConfigMap.tsx
@@ -230,6 +230,19 @@ export class OnlyonePortalPagesConfigMap {
             form: {
                 valueLabel: getMessageFor(bundle, "searchTagsPage.form.value.label"),
                 saveLabel: getMessageFor(bundle, "searchTagsPage.form.save.label")
+            },
+            editSearchTagModal: {
+                id: "editSearchTagModal",
+                title: getMessageFor(bundle, "searchTagsPage.editTag.popup.title"),
+                closeButtonLabel: getMessageFor(bundle, "common.button.close.label"),
+                saveButtonLabel: getMessageFor(bundle, "common.button.save.label")
+            },
+            deleteSearchTagModal: {
+                id: "deleteSearchTagModal",
+                title: getMessageFor(bundle, "searchTagsPage.deleteTag.popup.title"),
+                message: getMessageFor(bundle, "searchTagsPage.deleteTag.popup.message"),
+                yesLabel: getMessageFor(bundle, "common.confirm.yesLabel"),
+                noLabel: getMessageFor(bundle, "common.confirm.noLabel")
             }
         }
     }

--- a/portal/application-shell/src/messages/bundle/search-tags/message_bundle_en_en.yaml
+++ b/portal/application-shell/src/messages/bundle/search-tags/message_bundle_en_en.yaml
@@ -15,3 +15,10 @@ searchTagsPage:
       label: "Search Tag Value"
     save:
       label: "Save"
+  editTag:
+    popup:
+      title: "Edit Tag"
+  deleteTag:
+    popup:
+      title: "Delete Tag"
+      message: "Are you sure you want to delete this tag?"

--- a/portal/application-shell/src/messages/bundle/search-tags/message_bundle_it_it.yaml
+++ b/portal/application-shell/src/messages/bundle/search-tags/message_bundle_it_it.yaml
@@ -15,3 +15,10 @@ searchTagsPage:
       label: "Valore tag di ricerca"
     save:
       label: "Salva"
+  editTag:
+    popup:
+      title: "Modifica tag"
+  deleteTag:
+    popup:
+      title: "Elimina tag"
+      message: "Sei sicuro di voler eliminare questo tag?"

--- a/tagging/tag-api/CONTEXT.md
+++ b/tagging/tag-api/CONTEXT.md
@@ -5,7 +5,7 @@ Owns the per-user catalog of tags used to categorize budget records. Each user h
 ## Language
 
 **Tag**:
-A user-owned `(Key, Value, Scope)` tuple in the catalog. `Key` is a server-generated UUID, opaque and never chosen by the client; `Value` is the human-readable label the user picks (e.g. "Groceries"); `Scope` is mandatory — every `Tag` belongs to exactly one `Scope`.
+A user-owned `(Key, Value, Scope)` tuple in the catalog. `Key` is a server-generated UUID, minted once at creation and immutable thereafter — the client never chooses or changes it, only references an existing one (to update its `Value` or to delete it). `Value` is the human-readable label the user picks (e.g. "Groceries") and the only field a client can change once a `Tag` exists. `Scope` is mandatory at creation and, like `Key`, immutable afterward — every `Tag` belongs to exactly one `Scope` for its whole lifetime; re-classifying a tag's domain is delete-and-recreate, not update (see [ADR 0008](./docs/adr/0008-tag-update-is-value-only.md)). Update and delete both address a `Tag` by its `(Key, Scope)` composite identity — a request for a real `Key` through the wrong `Scope` is treated as not found, never as a cross-scope match.
 _Avoid_: Category, label
 
 **Scope**:

--- a/tagging/tag-api/adapter/dynamodb/repository.go
+++ b/tagging/tag-api/adapter/dynamodb/repository.go
@@ -2,6 +2,7 @@ package dynamodb
 
 import (
 	"context"
+	"errors"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	aws_config "github.com/aws/aws-sdk-go-v2/config"
@@ -123,4 +124,78 @@ func (r *TagDynamoDBRepository) FindAllTags(ctx context.Context, scope string) (
 	}
 
 	return tags, nil
+}
+
+// UpdateTagValue changes search_tag_value for the (user_name, search_tag_key)
+// item, conditioned on its stored scope matching tag.Scope. tag.Key and
+// tag.Scope are the lookup identity; tag.Value is the only field written. If
+// the item doesn't exist at all, or exists under a different scope, the
+// ConditionExpression fails the same way in both cases (DynamoDB treats a
+// missing attribute as not matching), so both collapse to ErrTagNotFound —
+// see docs/adr/0008-tag-update-is-value-only.md.
+func (r *TagDynamoDBRepository) UpdateTagValue(ctx context.Context, tag *domain.Tag) error {
+	user, err := security.GetCurrentUser(ctx)
+	if err != nil {
+		return err
+	}
+
+	_, err = r.Client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(r.TableName),
+		Key: map[string]types.AttributeValue{
+			"user_name":      &types.AttributeValueMemberS{Value: *user.UserName},
+			"search_tag_key": &types.AttributeValueMemberS{Value: tag.Key},
+		},
+		UpdateExpression: aws.String("SET search_tag_value = :value"),
+		ExpressionAttributeNames: map[string]string{
+			"#scope": "scope", // "scope" is a DynamoDB reserved keyword
+		},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":value": &types.AttributeValueMemberS{Value: tag.Value},
+			":scope": &types.AttributeValueMemberS{Value: tag.Scope},
+		},
+		ConditionExpression: aws.String("#scope = :scope"),
+	})
+
+	if err != nil {
+		var conditionFailed *types.ConditionalCheckFailedException
+		if errors.As(err, &conditionFailed) {
+			return domain.ErrTagNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+// DeleteTag removes the (user_name, search_tag_key) item, conditioned on its
+// stored scope matching the requested one — same not-found collapse as
+// UpdateTagValue above.
+func (r *TagDynamoDBRepository) DeleteTag(ctx context.Context, key string, scope string) error {
+	user, err := security.GetCurrentUser(ctx)
+	if err != nil {
+		return err
+	}
+
+	_, err = r.Client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+		TableName: aws.String(r.TableName),
+		Key: map[string]types.AttributeValue{
+			"user_name":      &types.AttributeValueMemberS{Value: *user.UserName},
+			"search_tag_key": &types.AttributeValueMemberS{Value: key},
+		},
+		ExpressionAttributeNames: map[string]string{
+			"#scope": "scope",
+		},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":scope": &types.AttributeValueMemberS{Value: scope},
+		},
+		ConditionExpression: aws.String("#scope = :scope"),
+	})
+
+	if err != nil {
+		var conditionFailed *types.ConditionalCheckFailedException
+		if errors.As(err, &conditionFailed) {
+			return domain.ErrTagNotFound
+		}
+		return err
+	}
+	return nil
 }

--- a/tagging/tag-api/adapter/dynamodb/repository_test.go
+++ b/tagging/tag-api/adapter/dynamodb/repository_test.go
@@ -190,3 +190,99 @@ func TestFindAllTagsWithScopeReturnsOnlyExactlyMatchingScope(t *testing.T) {
 		t.Errorf("Expected the differently-scoped tag to be excluded, got %+v", tags)
 	}
 }
+
+func TestUpdateTagValueChangesValueWhenScopeMatches(t *testing.T) {
+	repo := newTagDynamoDBRepository()
+	tag := domain.Tag{Key: "updateKey", Value: "before", Scope: "expense"}
+	if err := repo.SaveTag(newStubbedContext(), &tag); err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	if err := repo.UpdateTagValue(newStubbedContext(), &domain.Tag{Key: "updateKey", Scope: "expense", Value: "after"}); err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	tags, err := repo.FindAllTags(newStubbedContext(), "expense")
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	got := findTagByKey(tags, "updateKey")
+	if got == nil {
+		t.Fatalf("Expected to find tag with key %q, got %+v", "updateKey", tags)
+	}
+	if got.Value != "after" {
+		t.Errorf("Expected value %q, got %q", "after", got.Value)
+	}
+}
+
+func TestUpdateTagValueGivenWrongScopeReturnsNotFound(t *testing.T) {
+	repo := newTagDynamoDBRepository()
+	tag := domain.Tag{Key: "wrongScopeUpdateKey", Value: "before", Scope: "expense"}
+	if err := repo.SaveTag(newStubbedContext(), &tag); err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	err := repo.UpdateTagValue(newStubbedContext(), &domain.Tag{Key: "wrongScopeUpdateKey", Scope: "revenue", Value: "after"})
+	if !errors.Is(err, domain.ErrTagNotFound) {
+		t.Errorf("Expected ErrTagNotFound, got %v", err)
+	}
+}
+
+func TestUpdateTagValueGivenMissingKeyReturnsNotFound(t *testing.T) {
+	repo := newTagDynamoDBRepository()
+
+	err := repo.UpdateTagValue(newStubbedContext(), &domain.Tag{Key: "missingUpdateKey", Scope: "expense", Value: "after"})
+	if !errors.Is(err, domain.ErrTagNotFound) {
+		t.Errorf("Expected ErrTagNotFound, got %v", err)
+	}
+}
+
+func TestDeleteTagRemovesItWhenScopeMatches(t *testing.T) {
+	repo := newTagDynamoDBRepository()
+	tag := domain.Tag{Key: "deleteKey", Value: "value", Scope: "expense"}
+	if err := repo.SaveTag(newStubbedContext(), &tag); err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	if err := repo.DeleteTag(newStubbedContext(), "deleteKey", "expense"); err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	tags, err := repo.FindAllTags(newStubbedContext(), "expense")
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if findTagByKey(tags, "deleteKey") != nil {
+		t.Errorf("Expected the tag to be deleted, got %+v", tags)
+	}
+}
+
+func TestDeleteTagGivenWrongScopeReturnsNotFound(t *testing.T) {
+	repo := newTagDynamoDBRepository()
+	tag := domain.Tag{Key: "wrongScopeDeleteKey", Value: "value", Scope: "expense"}
+	if err := repo.SaveTag(newStubbedContext(), &tag); err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	err := repo.DeleteTag(newStubbedContext(), "wrongScopeDeleteKey", "revenue")
+	if !errors.Is(err, domain.ErrTagNotFound) {
+		t.Errorf("Expected ErrTagNotFound, got %v", err)
+	}
+
+	tags, findErr := repo.FindAllTags(newStubbedContext(), "expense")
+	if findErr != nil {
+		t.Errorf("Expected no error, got %v", findErr)
+	}
+	if findTagByKey(tags, "wrongScopeDeleteKey") == nil {
+		t.Errorf("Expected the tag to remain when the scope didn't match, got %+v", tags)
+	}
+}
+
+func TestDeleteTagGivenMissingKeyReturnsNotFound(t *testing.T) {
+	repo := newTagDynamoDBRepository()
+
+	err := repo.DeleteTag(newStubbedContext(), "missingDeleteKey", "expense")
+	if !errors.Is(err, domain.ErrTagNotFound) {
+		t.Errorf("Expected ErrTagNotFound, got %v", err)
+	}
+}

--- a/tagging/tag-api/docs/adr/0008-tag-update-is-value-only.md
+++ b/tagging/tag-api/docs/adr/0008-tag-update-is-value-only.md
@@ -1,0 +1,12 @@
+# Tag update is value-only; key and scope are immutable after creation
+
+Adding update and delete to the tag catalog (previously create-only, #28) raises the question of what update may change. `Tag` is a `(Key, Value, Scope)` tuple: `Key` is server-generated and already immutable by construction — the client never mints or chooses it. `Value` is the user-authored label and the obvious target of "rename this tag." `Scope` is the open question: could update also re-classify a tag from `expense` to `revenue`?
+
+Allowing `Scope` to change carries the same hazard as delete: a `Tag` referenced by real expense/revenue records, re-scoped, becomes unreachable from the scope those records still expect (`GET /api/tags/scope/expense` stops returning a tag now scoped to `revenue`), so budget-api's resolution of those records would need exactly the same non-destructive fallback this work is already adding for delete (see budget-api's ADR on the `UNKNOWN` fallback). Folding a second referential-integrity hazard into "update" — for a need (re-classifying a tag's domain) that's rare and already expressible as delete-old-create-new — buys nothing.
+
+`PATCH /api/tags/scope/:scope/:key` therefore accepts only `{ "value": "..." }`. `Key` and `Scope` together are the resource's identity, carried in the path, not in the writable body; a request whose `:key` does not carry `:scope` is rejected with `404`, the same composite-identity check `DELETE` uses. Targeting the synthesized `UNKNOWN` sentinel with either verb is rejected with `400` — it is never persisted, so there is nothing to update or delete.
+
+## Considered Options
+
+- **Value + scope mutable** — rejected: re-scoping a referenced tag is exactly as destructive to budget-api reads as deleting it, so it would need the same non-destructive-fallback machinery delete requires, for a need that's rare and already achievable as delete + create.
+- **Value-only mutable (chosen)** — keeps update free of the cross-service referential-integrity question entirely; `Key`/`Scope` stay the resource's fixed identity, `Value` is the only field a rename touches.

--- a/tagging/tag-api/domain/action.go
+++ b/tagging/tag-api/domain/action.go
@@ -15,5 +15,5 @@ func (action *FindAllTags) Execute(ctx context.Context, scope string) ([]Tag, er
 	if err != nil {
 		return nil, err
 	}
-	return append(tags, Tag{Key: "UNKNOWN", Value: "UNKNOWN"}), nil
+	return append(tags, Tag{Key: UnknownSentinelKey, Value: UnknownSentinelKey}), nil
 }

--- a/tagging/tag-api/domain/action_test.go
+++ b/tagging/tag-api/domain/action_test.go
@@ -21,6 +21,14 @@ func (m *findAllTagsMockRepo) FindAllTags(ctx context.Context, scope string) ([]
 	return m.tags, m.err
 }
 
+func (m *findAllTagsMockRepo) UpdateTagValue(ctx context.Context, tag *Tag) error {
+	return nil
+}
+
+func (m *findAllTagsMockRepo) DeleteTag(ctx context.Context, key string, scope string) error {
+	return nil
+}
+
 func TestFindAllTagsAppendsUnknownSentinel(t *testing.T) {
 	action := &FindAllTags{Repository: &findAllTagsMockRepo{tags: []Tag{{Key: "tag1", Value: "value1"}}}}
 

--- a/tagging/tag-api/domain/tags.go
+++ b/tagging/tag-api/domain/tags.go
@@ -2,8 +2,18 @@ package domain
 
 import (
 	"context"
+	"errors"
 	"strings"
 )
+
+// UnknownSentinelKey is the Key of the synthesized UNKNOWN sentinel tag (see
+// FindAllTags). It is never persisted, so update/delete reject it outright.
+const UnknownSentinelKey = "UNKNOWN"
+
+// ErrTagNotFound is returned by UpdateTagValue/DeleteTag when no tag matches
+// the given (key, scope) composite identity — either the key doesn't exist
+// at all, or it exists under a different Scope.
+var ErrTagNotFound = errors.New("tag not found")
 
 type Tag struct {
 	Key   string `json:"key"`
@@ -19,8 +29,17 @@ func NormalizeScope(scope string) string {
 
 type TagRepository interface {
 	SaveTag(ctx context.Context, tag *Tag) error
-	// FindAllTags returns the user's tags. An empty scope returns every tag
-	// unfiltered; a non-empty scope returns tags whose normalized Scope
-	// matches it plus unscoped tags (scope "" or unset).
+	// FindAllTags returns only the tags whose normalized Scope matches scope
+	// exactly — Scope is authoritative, see
+	// docs/adr/0007-scope-mandatory-and-scoped-reads-are-strict.md.
 	FindAllTags(ctx context.Context, scope string) ([]Tag, error)
+	// UpdateTagValue changes the Value of the tag identified by tag.Key and
+	// tag.Scope — those two fields are the lookup identity, not new values to
+	// write; Key and Scope are immutable — see
+	// docs/adr/0008-tag-update-is-value-only.md. Returns ErrTagNotFound when
+	// no tag matches that composite identity.
+	UpdateTagValue(ctx context.Context, tag *Tag) error
+	// DeleteTag deletes the tag identified by (key, scope). Returns
+	// ErrTagNotFound when no tag matches that composite identity.
+	DeleteTag(ctx context.Context, key string, scope string) error
 }

--- a/tagging/tag-api/web/api/endpoint.go
+++ b/tagging/tag-api/web/api/endpoint.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/mrflick72/onlyone-portal/core-services/golang-web-framework/logging"
@@ -54,6 +55,70 @@ func RegisterEndpoints(r *gin.Engine, contextFactoryConverter server.ContextFact
 		}
 
 		c.JSON(http.StatusCreated, tag)
+	})
+
+	// PATCH /api/tags/scope/:scope/:key — update only the Value of the tag at
+	// that (key, scope) composite identity. Key and Scope are immutable; a
+	// :key/:scope pair that doesn't match an existing tag is 404, and the
+	// UNKNOWN sentinel key is rejected with 400 since it is never persisted.
+	// See docs/adr/0008-tag-update-is-value-only.md.
+	r.PATCH("/api/tags/scope/:scope/:key", func(c *gin.Context) {
+		key := c.Param("key")
+		scope := domain.NormalizeScope(c.Param("scope"))
+
+		if key == domain.UnknownSentinelKey {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "the UNKNOWN sentinel tag cannot be updated"})
+			return
+		}
+
+		var body struct {
+			Value string `json:"value"`
+		}
+		if err := c.ShouldBindJSON(&body); err != nil {
+			logger.LogErrorfFor("error occurred: %v", err)
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		ctx := contextFactoryConverter.CreateContextFromGin(c)
+		err := repository.UpdateTagValue(ctx, &domain.Tag{Key: key, Scope: scope, Value: body.Value})
+		if errors.Is(err, domain.ErrTagNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+			return
+		}
+		if err != nil {
+			logger.LogErrorfFor("error occurred: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		c.Status(http.StatusNoContent)
+	})
+
+	// DELETE /api/tags/scope/:scope/:key — delete the tag at that (key, scope)
+	// composite identity. Same 404/400 rules as PATCH above.
+	r.DELETE("/api/tags/scope/:scope/:key", func(c *gin.Context) {
+		key := c.Param("key")
+		scope := domain.NormalizeScope(c.Param("scope"))
+
+		if key == domain.UnknownSentinelKey {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "the UNKNOWN sentinel tag cannot be deleted"})
+			return
+		}
+
+		ctx := contextFactoryConverter.CreateContextFromGin(c)
+		err := repository.DeleteTag(ctx, key, scope)
+		if errors.Is(err, domain.ErrTagNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+			return
+		}
+		if err != nil {
+			logger.LogErrorfFor("error occurred: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		c.Status(http.StatusNoContent)
 	})
 
 	return r

--- a/tagging/tag-api/web/api/endpoint_test.go
+++ b/tagging/tag-api/web/api/endpoint_test.go
@@ -126,6 +126,97 @@ func TestFindAllTagsByScopeAlwaysIncludesUnknownSentinel(t *testing.T) {
 	assert.Equal(t, "[{\"key\":\"UNKNOWN\",\"value\":\"UNKNOWN\"}]", w.Body.String())
 }
 
+func TestPatchTagUpdatesValue(t *testing.T) {
+	router := setupRouter()
+
+	mock := &MockRepo{tags: []domain.Tag{{Key: "tag1", Value: "Groceries", Scope: "expense"}}}
+	var repo domain.TagRepository = mock
+	RegisterEndpoints(router, &server.GinContextToPlainContextFactory{}, repo, &domain.FindAllTags{Repository: repo})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PATCH", "/api/tags/scope/expense/tag1", strings.NewReader(`{"value":"Supermarket"}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.Equal(t, "Supermarket", mock.tags[0].Value)
+}
+
+func TestPatchTagGivenWrongScopeReturnsNotFound(t *testing.T) {
+	router := setupRouter()
+
+	mock := &MockRepo{tags: []domain.Tag{{Key: "tag1", Value: "Groceries", Scope: "expense"}}}
+	var repo domain.TagRepository = mock
+	RegisterEndpoints(router, &server.GinContextToPlainContextFactory{}, repo, &domain.FindAllTags{Repository: repo})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PATCH", "/api/tags/scope/revenue/tag1", strings.NewReader(`{"value":"Supermarket"}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, "Groceries", mock.tags[0].Value, "the tag must not change when the scope doesn't match")
+}
+
+func TestPatchTagRejectsUnknownSentinelKey(t *testing.T) {
+	router := setupRouter()
+
+	mock := &MockRepo{tags: []domain.Tag{}}
+	var repo domain.TagRepository = mock
+	RegisterEndpoints(router, &server.GinContextToPlainContextFactory{}, repo, &domain.FindAllTags{Repository: repo})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PATCH", "/api/tags/scope/expense/UNKNOWN", strings.NewReader(`{"value":"Supermarket"}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestDeleteTagRemovesIt(t *testing.T) {
+	router := setupRouter()
+
+	mock := &MockRepo{tags: []domain.Tag{{Key: "tag1", Value: "Groceries", Scope: "expense"}}}
+	var repo domain.TagRepository = mock
+	RegisterEndpoints(router, &server.GinContextToPlainContextFactory{}, repo, &domain.FindAllTags{Repository: repo})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("DELETE", "/api/tags/scope/expense/tag1", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.Empty(t, mock.tags)
+}
+
+func TestDeleteTagGivenWrongScopeReturnsNotFound(t *testing.T) {
+	router := setupRouter()
+
+	mock := &MockRepo{tags: []domain.Tag{{Key: "tag1", Value: "Groceries", Scope: "expense"}}}
+	var repo domain.TagRepository = mock
+	RegisterEndpoints(router, &server.GinContextToPlainContextFactory{}, repo, &domain.FindAllTags{Repository: repo})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("DELETE", "/api/tags/scope/revenue/tag1", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Len(t, mock.tags, 1, "the tag must not be removed when the scope doesn't match")
+}
+
+func TestDeleteTagRejectsUnknownSentinelKey(t *testing.T) {
+	router := setupRouter()
+
+	mock := &MockRepo{tags: []domain.Tag{}}
+	var repo domain.TagRepository = mock
+	RegisterEndpoints(router, &server.GinContextToPlainContextFactory{}, repo, &domain.FindAllTags{Repository: repo})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("DELETE", "/api/tags/scope/expense/UNKNOWN", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
 // MockRepo is a simple in-memory implementation of domain.TagRepository for tests.
 type MockRepo struct {
 	tags []domain.Tag
@@ -146,4 +237,24 @@ func (m *MockRepo) FindAllTags(ctx context.Context, scope string) ([]domain.Tag,
 		}
 	}
 	return matching, nil
+}
+
+func (m *MockRepo) UpdateTagValue(ctx context.Context, tag *domain.Tag) error {
+	for i, t := range m.tags {
+		if t.Key == tag.Key && domain.NormalizeScope(t.Scope) == tag.Scope {
+			m.tags[i].Value = tag.Value
+			return nil
+		}
+	}
+	return domain.ErrTagNotFound
+}
+
+func (m *MockRepo) DeleteTag(ctx context.Context, key string, scope string) error {
+	for i, t := range m.tags {
+		if t.Key == key && domain.NormalizeScope(t.Scope) == scope {
+			m.tags = append(m.tags[:i], m.tags[i+1:]...)
+			return nil
+		}
+	}
+	return domain.ErrTagNotFound
 }

--- a/tagging/tag-api/web/api/endpoint_test.go
+++ b/tagging/tag-api/web/api/endpoint_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -30,8 +31,9 @@ func TestFindAllTagsByScopeGiveOnlyTheSentinelWhenScopeEmpty(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/api/tags/scope/expense", nil)
 	router.ServeHTTP(w, req)
 
+	expected, _ := json.Marshal([]domain.Tag{{Key: "UNKNOWN", Value: "UNKNOWN"}})
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "[{\"key\":\"UNKNOWN\",\"value\":\"UNKNOWN\"}]", w.Body.String())
+	assert.Equal(t, string(expected), w.Body.String())
 }
 
 func TestFindAllTagsByScopeGiveMatchingTagsPlusSentinel(t *testing.T) {
@@ -50,8 +52,13 @@ func TestFindAllTagsByScopeGiveMatchingTagsPlusSentinel(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/api/tags/scope/expense", nil)
 	router.ServeHTTP(w, req)
 
+	expected, _ := json.Marshal([]domain.Tag{
+		{Key: "tag1", Value: "value1", Scope: "expense"},
+		{Key: "tag2", Value: "value2", Scope: "expense"},
+		{Key: "UNKNOWN", Value: "UNKNOWN"},
+	})
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "[{\"key\":\"tag1\",\"value\":\"value1\",\"scope\":\"expense\"},{\"key\":\"tag2\",\"value\":\"value2\",\"scope\":\"expense\"},{\"key\":\"UNKNOWN\",\"value\":\"UNKNOWN\"}]", w.Body.String())
+	assert.Equal(t, string(expected), w.Body.String())
 }
 
 func TestPutTagRejectsBlankScope(t *testing.T) {
@@ -104,8 +111,12 @@ func TestFindAllTagsByScopeFiltersOutNonMatchingAndScopelessTags(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/api/tags/scope/EXPENSE", nil)
 	router.ServeHTTP(w, req)
 
+	expected, _ := json.Marshal([]domain.Tag{
+		{Key: "tag1", Value: "Groceries", Scope: "Expense"},
+		{Key: "UNKNOWN", Value: "UNKNOWN"},
+	})
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "[{\"key\":\"tag1\",\"value\":\"Groceries\",\"scope\":\"Expense\"},{\"key\":\"UNKNOWN\",\"value\":\"UNKNOWN\"}]", w.Body.String())
+	assert.Equal(t, string(expected), w.Body.String())
 }
 
 func TestFindAllTagsByScopeAlwaysIncludesUnknownSentinel(t *testing.T) {
@@ -122,8 +133,9 @@ func TestFindAllTagsByScopeAlwaysIncludesUnknownSentinel(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/api/tags/scope/revenue", nil)
 	router.ServeHTTP(w, req)
 
+	expected, _ := json.Marshal([]domain.Tag{{Key: "UNKNOWN", Value: "UNKNOWN"}})
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "[{\"key\":\"UNKNOWN\",\"value\":\"UNKNOWN\"}]", w.Body.String())
+	assert.Equal(t, string(expected), w.Body.String())
 }
 
 func TestPatchTagUpdatesValue(t *testing.T) {


### PR DESCRIPTION
## Summary

Started as docs only — design ADRs and CONTEXT.md updates for #28, resolved via /grilling. Implementation has since been added to this same branch:

- `tagging/tag-api/docs/adr/0008-tag-update-is-value-only.md` — update is value-only; `Key`/`Scope` immutable after creation, avoiding the same referential-integrity hazard delete has.
- `budget/budget-api/docs/adr/0003-deleted-tag-references-resolve-to-unknown-in-place.md` — `GetTagBy` resolves a deleted-tag reference to the `UNKNOWN` sentinel in place at read time; no DynamoDB write, no analytics update this iteration (durable migration + Kafka reindex deferred to #27).
- `tagging/tag-api/CONTEXT.md` — corrects the `Tag`/`Key` glossary entry now that the client references existing keys via update/delete, not just create.
- `budget/budget-api/CONTEXT.md` — new "Unresolvable Tag Reference" term.

### Implementation

- `tagging/tag-api`: `PATCH /api/tags/scope/:scope/:key` (value-only update) and `DELETE /api/tags/scope/:scope/:key`, both enforced against the `(key, scope)` composite identity via a DynamoDB `ConditionExpression`, collapsing both "missing" and "wrong scope" to `ErrTagNotFound` → `404`.
  - `TagRepository.UpdateTagValue` takes a `*domain.Tag` (`Key`/`Scope` as lookup identity, `Value` as the write) rather than loose primitives, to speak in domain terms and match the existing `SaveTag` convention; `DeleteTag` keeps primitive `(key, scope)` params since it carries no payload.
- `budget/budget-api`: REST/cache adapters updated so `GetTagBy` resolves a stale/deleted tag reference to the `UNKNOWN` sentinel in place.
- `portal/application-shell`: search-tags UI wired up to edit/delete existing tags end-to-end (update/delete pop-ups, English + Italian locale strings).
- Test readability cleanup: endpoint tests build the expected response as a Go object and `json.Marshal` it for comparison instead of a hand-typed escaped-quote JSON string (matches the existing `plan-api` test convention). Includes a boyscout commit applying the same fix to two pre-existing `core-services/golang-web-framework` tests with the same pattern.

Refs #28. Follow-up: #27.

## Test plan

- [x] `tagging/tag-api`: `go build`/`go vet`/`go test` pass (domain + web suites); LocalStack-backed adapter tests for `UpdateTagValue`/`DeleteTag` compile against the new signature but were not re-run against live LocalStack in this pass.
- [x] `budget/budget-api`: `go build`/`go vet` pass; confirmed no references to the changed `UpdateTagValue` signature (budget-api never called it).
- [x] `core-services/golang-web-framework`: affected packages (`web/management`, `middleware/security`) build/vet/test pass.
- [x] `portal/application-shell`: `npm run build` and `npm run type-check` pass.
- [ ] Manual browser verification of the search-tags edit/delete flow (English + Italian) — not yet performed in this environment.
